### PR TITLE
fix(githubLoader): infinite recursion of loadPage()

### DIFF
--- a/lib/githubLoader.js
+++ b/lib/githubLoader.js
@@ -79,12 +79,14 @@ module.exports = function GitHubAPI(options) {
       var hasLink = link && link.indexOf('next') >= 0;
       if (hasLink) {
         link = link.split(',');
-        link = link[0].match(/<(.*?)>/)[1];
+        if (link[0].indexOf('next') !== -1) {
+          link = link[0].match(/<(.*?)>/)[1];
+        } else if (link[1].indexOf('next') !== -1) {
+          link = link[1].match(/<(.*?)>/)[1];
+        }
       }
       return hasLink ? link : null;
     }
 
   }
 };
-
-


### PR DESCRIPTION
api's Link header now returns up to 4 links
"prev" link is first after the first page

Fixes #12