### PR TITLE
fix: Add check for author on commit summary

### DIFF
--- a/lib/committers.js
+++ b/lib/committers.js
@@ -47,8 +47,11 @@ module.exports = function $committers(options) {
        */
       function calculateSummaries(result) {
         return result.reduce( function (summary, it){
-          var count = summary[it.author.login] || 0;
-          summary[ it.author.login ] = count + 1;
+          if ( it.author ) {
+            var count = summary[it.author.login] || 0;
+            summary[it.author.login] = count + 1;
+          }
+
           return summary;
         }, { })
       }


### PR DESCRIPTION
Sometimes there is not `author` information returned for the commit. 
Here are some examples:
* ["Good" commit with author filed](https://api.github.com/repos/NativeScript/NativeScript/commits/3fcbbf4c12ff8b93d5b7f506762178d7245e2647)
* ["Bad" commit with no `author` (done trough the Web interface)](https://api.github.com/repos/NativeScript/NativeScript/commits/43fbabb5e9d383244ce5fa9926ad6b45de5e8c68). Note this one is done trough GitHub web interface - there is `committer` field with a `"login": "web-flow"`
* ["Bad" commit with no `author`](https://api.github.com/repos/NativeScript/NativeScript/commits/ef86addd6d4fdefebd0495588c7cdd9b0706688b). This one has no `author` and no `committer`

Note: In both "bad" commits there is "commit.author" field, however there is no `login` field there and I'm not sure if there is a way to get based on what's there (name/email). 

I have added a simple check on for the `author` field so that the program won't crash. These commits will not be handled by the tool so in this case their authors will be not be added in the end result :(