### PR TITLE
Updated merge to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/mgechev/github-contributors-list",
   "dependencies": {
     "marked": "~0.3.1",
-    "merge": "^1.2.0",
+    "merge": "^1.2.1",
     "minimist": "0.0.8",
     "q": "~1.4.1",
     "sprintf-js": "0.0.7"


### PR DESCRIPTION
There is a security issue with merge 1.2.0:

![screenshot from 2018-11-05 17-51-56](https://user-images.githubusercontent.com/1264099/48022912-8a962200-e123-11e8-9524-a79e3843a881.png)

I don't think that should any big issue on this project without update it, but at least will turn off that alert.