### PR TITLE
build(npm): fix dependency audit warnings

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Minko Gechev
+Copyright (c) 2014-2020 Minko Gechev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bin/githubcontrib
+++ b/bin/githubcontrib
@@ -68,7 +68,7 @@ function validateArgs() {
 }
 
 /**
- * Use specified strategy path or calculate the fullpath
+ * Use specified strategy path or calculate the full path
  * then load the strategy using `require()`
  */
 function validateStrategy(strategy, strategySrc) {

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -25,7 +25,7 @@ module.exports = function $contributors(options) {
       // Publish promise for the 2-step load process
 
       return q.Promise((resolve, reject) =>{
-        // Load list of commiters; each with a count of total # of commits
+        // Load list of committers; each with a count of total # of commits
         committers(options)
             .loadSince( owner, repository, authToken, since )
             .then( loadContributors )

--- a/lib/strategies/layout_strategies/table.js
+++ b/lib/strategies/layout_strategies/table.js
@@ -88,4 +88,3 @@ module.exports = function (options) {
   columnsCount = options.cols || 5;
   return formatter;
 };
-

--- a/lib/strategies/sort_strategies/sort_asc.js
+++ b/lib/strategies/sort_strategies/sort_asc.js
@@ -5,5 +5,4 @@ module.exports = function compareAsc(a, b, options) {
 
   return  (typeof a[prop] === 'number') ? a[prop] - b[prop] :
           ((aval > bval) ? 1 : (aval < bval) ? -1 : 0);
-}
-
+};

--- a/lib/strategies/sort_strategies/sort_desc.js
+++ b/lib/strategies/sort_strategies/sort_desc.js
@@ -13,5 +13,4 @@ module.exports = function compareDesc(a, b, options) {
       return 0;
     }
   }
-}
-
+};

--- a/lib/strategies/sort_strategies/sort_login.js
+++ b/lib/strategies/sort_strategies/sort_login.js
@@ -5,5 +5,4 @@ module.exports = function compareAsc(a, b, options) {
 
   return  (typeof a[prop] === 'number') ? a[prop] - b[prop] :
           ((aval > bval) ? 1 : (aval < bval) ? -1 : 0);
-}
-
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "github-contributors-list",
+  "version": "1.2.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "marked": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
+    },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "githubcontrib": "./bin/githubcontrib"
   },
   "scripts": {
+    "start": "./bin/githubcontrib",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -31,10 +32,10 @@
   },
   "homepage": "https://github.com/mgechev/github-contributors-list",
   "dependencies": {
-    "marked": "~0.3.1",
+    "marked": "^0.8.0",
     "merge": "^1.2.1",
-    "minimist": "0.0.8",
-    "q": "~1.4.1",
-    "sprintf-js": "0.0.7"
+    "minimist": "^1.2.0",
+    "q": "^1.5.1",
+    "sprintf-js": "^1.1.2"
   }
 }


### PR DESCRIPTION
- add package-lock.json to source
- update license copyright
- fix typos

AngularJS Material has gotten some [vulnerability alerts](https://github.com/angular/material/pull/11839) due to this devDependency and its older version of `marked`. This PR (and an associated new release) will help resolve this.